### PR TITLE
fix: Neutral Color Contrast Issues in DaisyUI Theme Generator

### DIFF
--- a/src/app/wizard/lib/color-utils.ts
+++ b/src/app/wizard/lib/color-utils.ts
@@ -320,6 +320,18 @@ export function generateContentColor(backgroundColor: string): string {
 	// 限制色度，保证颜色和背景稍微相关，但不过分饱和
 	const contentChroma = Math.min(chroma, 0.03) + 0.02;
 
+	// Special handling for neutral colors (very low chroma)
+	if (chroma < 0.05) {
+		// For neutral colors, we want to ensure good contrast
+		if (lightness < THRESHOLD) {
+			// Dark neutral background: generate light content
+			return `oklch(97% ${contentChroma.toFixed(3)} ${hue.toFixed(3)})`;
+		}
+		// Light neutral background: generate dark content
+		return `oklch(3% ${contentChroma.toFixed(3)} ${hue.toFixed(3)})`;
+	}
+
+	// Standard handling for colored backgrounds
 	if (lightness > THRESHOLD) {
 		// 背景较亮：生成接近黑色的内容色（极深）
 		return `oklch(3% ${contentChroma.toFixed(3)} ${hue.toFixed(3)})`;

--- a/src/app/wizard/lib/generate-theme.ts
+++ b/src/app/wizard/lib/generate-theme.ts
@@ -45,11 +45,11 @@ export function generateThemeCSS(props: ThemeGenerationProps): string {
 	const errorContent = generateContentColor(error);
 
 	// Generate neutral colors for light theme
-	const neutral = "oklch(20.5% 0 0)"; // Neutral/gray color for light theme
+	const neutral = "oklch(75% 0 0)"; // Neutral/gray color for light theme
 	const neutralContent = generateContentColor(neutral);
 
 	// Generate neutral colors for dark theme
-	const darkNeutral = "oklch(97% 0 0)"; // Lighter neutral/gray color for dark theme
+	const darkNeutral = "oklch(25% 0 0)"; // Darker neutral/gray color for dark theme
 	const darkNeutralContent = generateContentColor(darkNeutral);
 
 	// Generate base colors based on primary
@@ -64,7 +64,16 @@ export function generateThemeCSS(props: ThemeGenerationProps): string {
  * Generated DaisyUI Theme for Tailwind CSS v4
  * Created with DaisyUI Theme Generator
  */
-@import url('https://fonts.googleapis.com/css2?family=${fonts.heading.replace(/ /g, "+")}:wght@400;700&family=${fonts.body.replace(/ /g, "+")}:wght@400;700&family=${fonts.mono.replace(/ /g, "+")}:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=${fonts.heading.replace(
+		/ /g,
+		"+",
+	)}:wght@400;700&family=${fonts.body.replace(
+		/ /g,
+		"+",
+	)}:wght@400;700&family=${fonts.mono.replace(
+		/ /g,
+		"+",
+	)}:wght@400;700&display=swap');
 @import 'tailwindcss';
 
 @theme {


### PR DESCRIPTION
## Issue
The neutral color in the light theme was set to oklch(20.5% 0 0), which is a very dark color. This caused a contrast issue because the theme generator was treating it as a dark color and generating light content text (oklch(97% 0.001 56.259)), which resulted in poor visibility in the light theme.
## Changes Made
Changed light theme neutral color from oklch(20.5% 0 0) (dark) to oklch(75% 0 0) (light)
Changed dark theme neutral color from oklch(97% 0 0) (very light) to oklch(25% 0 0) (dark)
Added special handling in generateContentColor function for neutral colors (very low chroma) to ensure proper contrast
## Technical Details
The color utility functions now properly handle neutral colors with low chroma values, distinguishing between dark and light backgrounds to generate appropriate content colors. This ensures good readability across both light and dark themes.
## Testing
Verified that the neutral colors now correctly generate contrasting content colors:
Light theme neutral (75% lightness) → dark content (3% lightness)
Dark theme neutral (25% lightness) → light content (97% lightness)